### PR TITLE
Fix JWT expiration types

### DIFF
--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -161,7 +161,7 @@ export const generateToken = (payload: {
   role: 'USER' | 'ADMIN' | 'PREMIUM';
 }): string => {
   return jwt.sign(payload, config.jwtSecret, {
-    expiresIn: config.jwtExpiresIn
+    expiresIn: config.jwtExpiresIn as jwt.SignOptions['expiresIn']
   });
 };
 

--- a/backend/src/utils/configUtils.ts
+++ b/backend/src/utils/configUtils.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import path from 'path';
+import type { StringValue } from 'ms';
 
 // Load environment variables
 dotenv.config({ path: path.join(__dirname, '../../../.env') });
@@ -8,7 +9,7 @@ export interface AppConfig {
   port: number;
   nodeEnv: string;
   jwtSecret: string;
-  jwtExpiresIn: string;
+  jwtExpiresIn: StringValue | number;
   apiKeys: {
     geminiPro: string;
     geminiFlash: string;
@@ -37,7 +38,7 @@ const config: AppConfig = {
   port: parseInt(process.env.PORT || '5000', 10),
   nodeEnv: process.env.NODE_ENV || 'development',
   jwtSecret: process.env.JWT_SECRET || 'fallback-secret-key',
-  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '24h',
+  jwtExpiresIn: (process.env.JWT_EXPIRES_IN as StringValue | undefined) || '24h',
   apiKeys: {
     geminiPro: process.env.API_KEY_GEMINI_PRO || '',
     geminiFlash: process.env.API_KEY_GEMINI_FLASH || '',


### PR DESCRIPTION
## Summary
- widen jwt expiration typing in config utility
- cast JWT_EXPIRES_IN env var to `StringValue`
- ensure `generateToken` sets `expiresIn` using jwt.SignOptions typing

## Testing
- `npm run build --prefix backend` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686e5453a3e083258242ea31d9c2a453